### PR TITLE
Refer to velocity as "velocity" in documentation and other names

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,8 +5,8 @@ fn main() {
     // Let's use floating point numbers here to keep the example simple.
     // RampMaker also supports fixed-point numbers though.
     let target_accel = 1000.0; // meters per second^2
-    let max_speed = 1500.0; // meters per second
-    let profile = ramp_maker::Trapezoidal::new(target_accel, max_speed);
+    let max_velocity = 1500.0; // meters per second
+    let profile = ramp_maker::Trapezoidal::new(target_accel, max_velocity);
 
     let num_steps = 2000;
     for delay in profile.ramp(num_steps) {

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -11,13 +11,13 @@ use crate::MotionProfile;
 /// Flat motion profile
 ///
 /// This is the simplest possible motion profile, as it produces just a constant
-/// speed. Please note that this is of limited use, and should probably be
+/// velocity. Please note that this is of limited use, and should probably be
 /// restricted to testing.
 ///
 /// Theoretically, this profile produces infinite acceleration/deceleration at
 /// the beginning and end of the movement. In practice, you might get away with
-/// this, if the speed and the load on the motor are low enough. Otherwise, this
-/// will definitely produce missed steps.
+/// this, if the velocity and the load on the motor are low enough. Otherwise,
+/// this will definitely produce missed steps.
 ///
 /// Create an instance of this struct using [`Flat::new`], then use the API
 /// defined by [`MotionProfile`] (which this struct implements) to generate the
@@ -26,17 +26,17 @@ use crate::MotionProfile;
 /// # Unit of Time
 ///
 /// This code is agnostic on which unit of time is used. If you provide the
-/// target speed in steps per second, the unit of the delay returned will be
+/// target velocity in steps per second, the unit of the delay returned will be
 /// seconds.
 ///
-/// This allows you to pass the target speed in steps per number of timer counts
-/// for the timer you're using, completely eliminating any conversion overhead
-/// for the delay.
+/// This allows you to pass the target velocity in steps per number of timer
+/// counts for the timer you're using, completely eliminating any conversion
+/// overhead for the delay.
 ///
 /// # Type Parameter
 ///
 /// The type parameter `Num` defines the type that is used to represent the
-/// target speed and the delay per step. It is set to a 32-bit fixed-point
+/// target velocity and the delay per step. It is set to a 32-bit fixed-point
 /// number type by default.
 ///
 /// This default is appropriate for 32-bit microcontrollers, but it might not
@@ -51,10 +51,10 @@ impl<Num> Flat<Num>
 where
     Num: num_traits::One + ops::Div<Output = Num>,
 {
-    /// Create a `Flat` instance by passing a target speed
+    /// Create a `Flat` instance by passing a target velocity
     ///
-    /// The target speed is specified in steps per unit of time (see top-level
-    /// documentation of this struct) and must not be zero.
+    /// The target velocity is specified in steps per unit of time (see
+    /// top-level documentation of this struct) and must not be zero.
     ///
     /// # Panics
     ///
@@ -77,7 +77,7 @@ where
     /// iterator that yields one delay value per step, and `None` after that.
     ///
     /// Since this is the flat motion profile, all delay values yielded will be
-    /// the same (as defined by the target speed passed to the constructor).
+    /// the same (as defined by the target velocity passed to the constructor).
     fn ramp(&self, num_steps: usize) -> Self::Iter {
         Iter {
             delay: self.delay,

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -58,9 +58,9 @@ where
     ///
     /// # Panics
     ///
-    /// Panics, if `target_speed` is zero.
-    pub fn new(target_speed: Num) -> Self {
-        let delay = Num::one() / target_speed;
+    /// Panics, if `target_velocity` is zero.
+    pub fn new(target_velocity: Num) -> Self {
+        let delay = Num::one() / target_velocity;
         Self { delay }
     }
 }

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -131,7 +131,7 @@ mod tests {
     }
 
     #[test]
-    fn flat_should_produce_constant_speed() {
+    fn flat_should_produce_constant_velocity() {
         let flat = Flat::new(2.0); // steps per second
 
         for delay in flat.ramp(200) {

--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -297,7 +297,7 @@ mod tests {
     }
 
     #[test]
-    fn trapezoidal_should_respect_maximum_speed() {
+    fn trapezoidal_should_respect_maximum_velocity() {
         let max_velocity = 1000.0; // steps per second
         let trapezoidal = Trapezoidal::new(6000.0, max_velocity);
 

--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -87,17 +87,17 @@ where
     ///
     /// Accepts two arguments:
     /// - `target_accel`, the target acceleration in steps per (unit of time)^2.
-    /// - `max_speed`, the maximum velocity in steps per unit of time.
+    /// - `max_velocity`, the maximum velocity in steps per unit of time.
     ///
     /// Both parameters must not be zero. See the struct documentation for
     /// information about units of time.
     ///
     /// # Panics
     ///
-    /// Panics, if `target_accel` or `max_speed` are zero.
-    pub fn new(target_accel: Num, max_speed: Num) -> Self {
+    /// Panics, if `target_accel` or `max_velocity` are zero.
+    pub fn new(target_accel: Num, max_velocity: Num) -> Self {
         // Based on equation [7] in the reference paper.
-        let min_delay = max_speed.inv();
+        let min_delay = max_velocity.inv();
 
         // Based on equation [17] in the referenced paper.
         let two = Num::one() + Num::one();

--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -440,10 +440,10 @@ mod tests {
         let mut accel = None;
 
         if let &mut Some(delay_prev) = delay_prev {
-            let speed_prev = 1.0 / delay_prev;
-            let speed_curr = 1.0 / delay_curr;
+            let velocity_prev = 1.0 / delay_prev;
+            let velocity_curr = 1.0 / delay_curr;
 
-            let speed_diff: f32 = speed_curr - speed_prev;
+            let velocity_diff: f32 = velocity_curr - velocity_prev;
 
             // - Assumes the velocity defined by a given delay to be reached at
             //   the mid-point between the two steps that the delay separates.
@@ -455,7 +455,7 @@ mod tests {
             //   the points in time at which the two velocities are reached.
             let time_diff = delay_prev / 2.0 + delay_curr / 2.0;
 
-            accel = Some(speed_diff / time_diff);
+            accel = Some(velocity_diff / time_diff);
         }
 
         *delay_prev = Some(delay_curr);

--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -298,8 +298,8 @@ mod tests {
 
     #[test]
     fn trapezoidal_should_respect_maximum_speed() {
-        let max_speed = 1000.0; // steps per second
-        let trapezoidal = Trapezoidal::new(6000.0, max_speed);
+        let max_velocity = 1000.0; // steps per second
+        let trapezoidal = Trapezoidal::new(6000.0, max_velocity);
 
         let min_delay = 0.001; // seconds
         for delay in trapezoidal.ramp(200) {

--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -25,8 +25,8 @@ use crate::MotionProfile;
 /// This implementation makes the following simplifications:
 /// - The unit of time used is left to the user (see "Unit of Time" below), so
 ///   the frequency variable `F` is ignored.
-/// - The initial speed `v0` is assumed to be zero, making this implementation
-///   suitable only for starting and stopping at a stand-still.
+/// - The initial velocity `v0` is assumed to be zero, making this
+///   implementation suitable only for starting and stopping at a stand-still.
 /// - None of the optional enhancements are implemented.
 ///
 /// Create an instance of this struct using [`Trapezoidal::new`], then use the
@@ -37,16 +37,16 @@ use crate::MotionProfile;
 ///
 /// This struct will generate a trapezoidal acceleration ramp with the following
 /// attributes:
-/// - The speed will always be equal to or less than the maximum speed passed to
-///   the constructor.
+/// - The velocity will always be equal to or less than the maximum velocity
+///   passed to the constructor.
 /// - While ramping up or down, the acceleration will be an approximation
 ///   of the target acceleration passed to the constructor.
 ///
 /// # Unit of Time
 ///
 /// This code is agnostic on which unit of time is used. If you provide the
-/// target acceleration and maximum speed in steps per second, the unit of the
-/// delay returned will be seconds.
+/// target acceleration and maximum velocity in steps per second, the unit of
+/// the delay returned will be seconds.
 ///
 /// This allows you to pass the parameters in steps per number of timer counts
 /// for the timer you're using, completely eliminating any conversion overhead
@@ -55,7 +55,7 @@ use crate::MotionProfile;
 /// # Type Parameter
 ///
 /// The type parameter `Num` defines the type that is used to represent the
-/// target acceleration, maximum speed, and delays per step. It is set to a
+/// target acceleration, maximum velocity, and delays per step. It is set to a
 /// 64-bit fixed-point number type by default.
 ///
 /// You can override the default with `f32`, `f64`, or any other type from the
@@ -87,7 +87,7 @@ where
     ///
     /// Accepts two arguments:
     /// - `target_accel`, the target acceleration in steps per (unit of time)^2.
-    /// - `max_speed`, the maximum speed in steps per unit of time.
+    /// - `max_speed`, the maximum velocity in steps per unit of time.
     ///
     /// Both parameters must not be zero. See the struct documentation for
     /// information about units of time.
@@ -445,14 +445,14 @@ mod tests {
 
             let speed_diff: f32 = speed_curr - speed_prev;
 
-            // - Assumes the speed defined by a given delay to be reached at the
-            //   mid-point between the two steps that the delay separates.
-            // - Because of this, the interval between the time of the speed
+            // - Assumes the velocity defined by a given delay to be reached at
+            //   the mid-point between the two steps that the delay separates.
+            // - Because of this, the interval between the time of the velocity
             //   being reached and the time of a neighboring step being
             //   initiated, is half the delay (the delay measures the interval
             //   between two steps).
             // - Therefore, the formula below computes the difference between
-            //   the points in time at which the two speeds are reached.
+            //   the points in time at which the two velocities are reached.
             let time_diff = delay_prev / 2.0 + delay_curr / 2.0;
 
             accel = Some(speed_diff / time_diff);


### PR DESCRIPTION
See first commit for an explanation.