### PR TITLE
Improve accuracy of trapezoidal motion profile

### DIFF
--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -301,7 +301,7 @@ mod tests {
                     Mode::RampDown => {
                         ramped_down = true;
 
-                        assert!(accel < 0.0);
+                        assert!(accel <= 0.0);
                     }
                 }
             }

--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -26,7 +26,6 @@ use crate::{
 ///   the frequency variable `F` is ignored.
 /// - The initial velocity `v0` is assumed to be zero, making this
 ///   implementation suitable only for starting and stopping at a stand-still.
-/// - None of the optional enhancements are implemented.
 ///
 /// Create an instance of this struct using [`Trapezoidal::new`], then use the
 /// API defined by [`MotionProfile`] (which this struct implements) to generate
@@ -180,26 +179,30 @@ where
             return None;
         }
 
-        let velocity = self.delay_prev.inv();
+        // Compute some basic numbers we're going to need for the following
+        // calculations. All of this is statically known, so let's hope it
+        // optimizes out.
         let two = Num::one() + Num::one();
+        let three = two + Num::one();
+        let one_five = three / two;
+
+        let velocity = self.delay_prev.inv();
         let steps_to_stop = (velocity * velocity) / (two * self.target_accel);
         let steps_to_stop = steps_to_stop.ceil().az::<u32>();
 
-        // Compute the delay for the next step. See [20] in the referenced
+        // Compute the delay for the next step. See [22] in the referenced
         // paper.
         //
         // We don't differentiate between acceleration and plateau here, as we
         // clamp the delay value further down anyway, which creates the plateau.
+        let q = self.target_accel * self.delay_prev * self.delay_prev;
+        let addend = one_five * q * q;
         let delay_next = if self.steps_left > steps_to_stop {
             // Ramping up
-            self.delay_prev
-                * (Num::one()
-                    - self.target_accel * self.delay_prev * self.delay_prev)
+            self.delay_prev * (Num::one() - q + addend)
         } else {
             // Ramping down
-            self.delay_prev
-                * (Num::one()
-                    + self.target_accel * self.delay_prev * self.delay_prev)
+            self.delay_prev * (Num::one() + q + addend)
         };
 
         // Ensure that `delay_min <= delay_next <= delay_initial`. See the
@@ -339,7 +342,7 @@ mod tests {
                         target_accel,
                         // It's much more accurate for the most part, but can be
                         // quite inaccurate at the beginning and end.
-                        epsilon = target_accel * 0.2,
+                        epsilon = target_accel * 0.05,
                     );
                 }
             }


### PR DESCRIPTION
This uses a more expensive computation, but I think that's the best trade-off for now. I'm currently working on making the motion profiles more flexible, and I'm running into accuracy problems with the trapezoidal ramp. I think it's better for now to just make it accurate and deal with optimization later (if necessary).

Close #3 