### PR TITLE
Make `MotionProfile` more powerful and flexible

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,10 +6,12 @@ fn main() {
     // RampMaker also supports fixed-point numbers though.
     let target_accel = 1000.0; // meters per second^2
     let max_velocity = 1500.0; // meters per second
-    let profile = ramp_maker::Trapezoidal::new(target_accel, max_velocity);
+    let mut profile = ramp_maker::Trapezoidal::new(target_accel, max_velocity);
 
     let num_steps = 2000;
-    for delay in profile.ramp(num_steps) {
+    profile.enter_position_mode(num_steps);
+
+    for delay in profile.ramp() {
         // How you handle a delay depends on the platform you're running on
         // (RampMaker works pretty much everywhere). Here, we use a fake `Timer`
         // API, to demonstrate how the delays produced by RampMaker must be

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,7 +12,7 @@ fn main() {
     let num_steps = 2000;
     profile.enter_position_mode(max_velocity, num_steps);
 
-    for delay in profile.ramp() {
+    while let Some(delay) = profile.next_delay() {
         // How you handle a delay depends on the platform you're running on
         // (RampMaker works pretty much everywhere). Here, we use a fake `Timer`
         // API, to demonstrate how the delays produced by RampMaker must be

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,10 +6,11 @@ fn main() {
     // RampMaker also supports fixed-point numbers though.
     let target_accel = 1000.0; // meters per second^2
     let max_velocity = 1500.0; // meters per second
-    let mut profile = ramp_maker::Trapezoidal::new(target_accel, max_velocity);
+
+    let mut profile = ramp_maker::Trapezoidal::new(target_accel);
 
     let num_steps = 2000;
-    profile.enter_position_mode(num_steps);
+    profile.enter_position_mode(max_velocity, num_steps);
 
     for delay in profile.ramp() {
         // How you handle a delay depends on the platform you're running on

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,7 +12,7 @@ fn main() {
     let num_steps = 2000;
     profile.enter_position_mode(max_velocity, num_steps);
 
-    while let Some(delay) = profile.next_delay() {
+    for delay in profile.iter() {
         // How you handle a delay depends on the platform you're running on
         // (RampMaker works pretty much everywhere). Here, we use a fake `Timer`
         // API, to demonstrate how the delays produced by RampMaker must be

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -56,8 +56,6 @@ impl<Num> Flat<Num> {
     }
 }
 
-// Needed for the `MotionProfile` test suite in `crate::util::testing`.
-#[cfg(test)]
 impl Default for Flat<f32> {
     fn default() -> Self {
         Self::new()

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -111,7 +111,7 @@ mod tests {
         let mut flat = Flat::new();
 
         flat.enter_position_mode(2.0, 200);
-        while let Some(delay) = flat.next_delay() {
+        for delay in flat.iter() {
             assert_eq!(delay, 0.5);
         }
     }

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -64,7 +64,7 @@ impl Default for Flat<f32> {
 
 impl<Num> MotionProfile for Flat<Num>
 where
-    Num: Copy + num_traits::Inv<Output = Num>,
+    Num: Copy + num_traits::Zero + num_traits::Inv<Output = Num>,
 {
     type Velocity = Num;
     type Delay = Num;
@@ -74,7 +74,12 @@ where
         max_velocity: Self::Velocity,
         num_steps: u32,
     ) {
-        self.delay = Some(max_velocity.inv());
+        self.delay = if max_velocity.is_zero() {
+            None
+        } else {
+            Some(max_velocity.inv())
+        };
+
         self.num_steps = num_steps;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,21 @@ pub trait MotionProfile {
     /// The iterator returned by [`MotionProfile::ramp`]
     type Iter: Iterator<Item = Self::Delay>;
 
+    /// Enter position mode
+    ///
+    /// In position mode, the motion profile will attempt to move for a specific
+    /// number of steps and come to a stand-still at the target step.
+    ///
+    /// The number of steps given here is always relative to the current
+    /// position, as implementations of this trait are not expected to keep
+    /// track of an absolute position.
+    fn enter_position_mode(&mut self, num_steps: u32);
+
     /// Generate the acceleration ramp
     ///
-    /// `num_steps` defines the number of steps in the acceleration ramp. The
-    /// returned iterator yields one value per step, each value defining a delay
-    /// between two steps.
+    /// The returned iterator yields one value per step, as defined by the call
+    /// to [`enter_position_mode`], each value defining a delay between two
+    /// steps.
     ///
     /// Note that for n steps, only n-1 delay values are actually needed. The
     /// additional delay value will lead to an unnecessary delay before the
@@ -60,5 +70,7 @@ pub trait MotionProfile {
     ///
     /// All other details of the acceleration ramp, as well as the unit of the
     /// yielded delay values, are implementation-defined.
-    fn ramp(&self, num_steps: u32) -> Self::Iter;
+    ///
+    /// [`enter_position_mode`]: MotionProfile::enter_position_mode
+    fn ramp(&self) -> Self::Iter;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,6 @@ pub trait MotionProfile {
     /// The type used for representing delay values
     type Delay;
 
-    /// The iterator returned by [`MotionProfile::ramp`]
-    type Iter: Iterator<Item = Self::Delay>;
-
     /// Enter position mode
     ///
     /// In position mode, the motion profile will attempt to move for a specific
@@ -61,23 +58,20 @@ pub trait MotionProfile {
         num_steps: u32,
     );
 
-    /// Generate the acceleration ramp
+    /// Return the next step delay
     ///
-    /// The returned iterator yields one value per step, as defined by the call
-    /// to [`enter_position_mode`], each value defining a delay between two
-    /// steps.
+    /// Produces the delay for the next step. The unit of this delay is
+    /// implementation-defined. `None` is returned, if no more steps need to be
+    /// taken. This happens when reaching the target step in position mode, or
+    /// if velocity is set to zero in either position or velocity mode.
     ///
-    /// Note that for n steps, only n-1 delay values are actually needed. The
-    /// additional delay value will lead to an unnecessary delay before the
-    /// first or after the last step. This was done to make accidental misuse of
-    /// this method less likely, as the most straight-forward use of this method
-    /// is to iterate over all values and make one step per value. If the
-    /// additional delay value is relevant for your application, you can just
-    /// ignore it.
+    /// Please note that motion profiles yield one value per step, even though
+    /// only n-1 delay values are needed for n steps. The additional delay value
+    /// will lead to an unnecessary delay before the first or after the last
+    /// step. This was done to make accidental misuse of this trait less likely,
+    /// as the most straight-forward use is to make one step per delay value in
+    /// a loop.
     ///
-    /// All other details of the acceleration ramp, as well as the unit of the
-    /// yielded delay values, are implementation-defined.
-    ///
-    /// [`enter_position_mode`]: MotionProfile::enter_position_mode
-    fn ramp(&self) -> Self::Iter;
+    /// All other details of the motion profile are implementation-defined.
+    fn next_delay(&mut self) -> Option<Self::Delay>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ pub use self::{flat::Flat, trapezoidal::Trapezoidal};
 /// write abstract code that doesn't care about the specific motion profile
 /// used.
 pub trait MotionProfile {
+    /// The type used for representing velocities
+    type Velocity;
+
     /// The type used for representing delay values
     type Delay;
 
@@ -52,7 +55,11 @@ pub trait MotionProfile {
     /// The number of steps given here is always relative to the current
     /// position, as implementations of this trait are not expected to keep
     /// track of an absolute position.
-    fn enter_position_mode(&mut self, num_steps: u32);
+    fn enter_position_mode(
+        &mut self,
+        max_velocity: Self::Velocity,
+        num_steps: u32,
+    );
 
     /// Generate the acceleration ramp
     ///

--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -121,6 +121,7 @@ where
     Num: Copy
         + PartialOrd
         + az::Cast<u32>
+        + num_traits::Zero
         + num_traits::One
         + num_traits::Inv<Output = Num>
         + ops::Add<Output = Num>
@@ -138,7 +139,11 @@ where
         num_steps: u32,
     ) {
         // Based on equation [7] in the reference paper.
-        self.delay_min = Some(max_velocity.inv());
+        self.delay_min = if max_velocity.is_zero() {
+            None
+        } else {
+            Some(max_velocity.inv())
+        };
 
         self.steps_left = num_steps;
     }

--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -243,21 +243,6 @@ mod tests {
     }
 
     #[test]
-    fn trapezoidal_should_respect_maximum_velocity() {
-        let mut trapezoidal = Trapezoidal::new(6000.0);
-
-        let max_velocity = 1000.0; // steps per second
-        trapezoidal.enter_position_mode(max_velocity, 200);
-
-        let min_delay = 0.001; // seconds
-
-        for delay in trapezoidal.ramp() {
-            println!("delay: {}, min_delay: {}", delay, min_delay);
-            assert!(delay >= min_delay);
-        }
-    }
-
-    #[test]
     fn trapezoidal_should_come_to_stop_with_last_step() {
         let mut trapezoidal = Trapezoidal::new(6000.0);
 

--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -215,7 +215,7 @@ mod tests {
         let mut last_velocity = None;
 
         trapezoidal.enter_position_mode(1000.0, 200);
-        while let Some(delay) = trapezoidal.next_delay() {
+        for delay in trapezoidal.iter() {
             let velocity = 1.0 / delay;
             println!("Velocity: {}", velocity);
             last_velocity = Some(velocity);
@@ -243,10 +243,8 @@ mod tests {
         let mut plateaued = false;
         let mut ramped_down = false;
 
-        let mut i = 0;
-
         trapezoidal.enter_position_mode(1000.0, 200);
-        while let Some(delay_curr) = trapezoidal.next_delay() {
+        for (i, delay_curr) in trapezoidal.iter().enumerate() {
             if let Some(accel) =
                 acceleration_from_delays(&mut delay_prev, delay_curr)
             {
@@ -278,8 +276,6 @@ mod tests {
                     }
                 }
             }
-
-            i += 1;
         }
 
         assert!(ramped_up);
@@ -298,9 +294,8 @@ mod tests {
         trapezoidal.enter_position_mode(1000.0, num_steps);
 
         let mut delay_prev = None;
-        let mut i = 0;
 
-        while let Some(delay_curr) = trapezoidal.next_delay() {
+        for (i, delay_curr) in trapezoidal.iter().enumerate() {
             if let Some(accel) =
                 acceleration_from_delays(&mut delay_prev, delay_curr)
             {
@@ -321,8 +316,6 @@ mod tests {
                     );
                 }
             }
-
-            i += 1;
         }
     }
 

--- a/src/util/testing.rs
+++ b/src/util/testing.rs
@@ -11,9 +11,15 @@
 #![cfg(test)]
 
 /// Alias for [`crate::MotionProfile`] with some extras, used by the tests here
-pub trait MotionProfile: crate::MotionProfile + Default {}
+pub trait MotionProfile:
+    crate::MotionProfile<Velocity = f32> + Default
+{
+}
 
-impl<T> MotionProfile for T where T: crate::MotionProfile + Default {}
+impl<T> MotionProfile for T where
+    T: crate::MotionProfile<Velocity = f32> + Default
+{
+}
 
 /// Run full test suite on the provided [`MotionProfile`] implementation
 pub fn test<Profile>()
@@ -28,7 +34,7 @@ pub fn position_mode_must_produce_correct_number_of_steps(
     mut profile: impl MotionProfile,
 ) {
     let num_steps = 200;
-    profile.enter_position_mode(num_steps);
+    profile.enter_position_mode(1000.0, num_steps);
 
     assert_eq!(profile.ramp().count() as u32, num_steps);
 }

--- a/src/util/testing.rs
+++ b/src/util/testing.rs
@@ -37,7 +37,12 @@ pub fn position_mode_must_produce_correct_number_of_steps(
     let num_steps = 200;
     profile.enter_position_mode(1000.0, num_steps);
 
-    assert_eq!(profile.ramp().count() as u32, num_steps);
+    let mut count = 0;
+    while let Some(_delay) = profile.next_delay() {
+        count += 1;
+    }
+
+    assert_eq!(count, num_steps);
 }
 
 /// A motion in position mode must respect the maximum velocity
@@ -49,7 +54,7 @@ pub fn position_mode_must_respect_maximum_velocity(
 
     let min_delay = 0.001;
 
-    for delay in profile.ramp() {
+    while let Some(delay) = profile.next_delay() {
         println!("delay: {}, min_delay: {}", delay, min_delay);
         assert!(delay >= min_delay);
     }

--- a/src/util/testing.rs
+++ b/src/util/testing.rs
@@ -28,6 +28,7 @@ where
 {
     position_mode_must_produce_correct_number_of_steps(Profile::default());
     position_mode_must_respect_maximum_velocity(Profile::default());
+    position_mode_must_not_panic_because_of_zero_velocity(Profile::default());
 }
 
 /// A motion in position mode must produce the correct number of steps
@@ -58,4 +59,12 @@ pub fn position_mode_must_respect_maximum_velocity(
         println!("delay: {}, min_delay: {}", delay, min_delay);
         assert!(delay >= min_delay);
     }
+}
+
+/// Entering position mode with a max velocity of zero must not cause a panic
+pub fn position_mode_must_not_panic_because_of_zero_velocity(
+    mut profile: impl MotionProfile,
+) {
+    profile.enter_position_mode(0.0, 200);
+    assert_eq!(profile.next_delay(), None);
 }

--- a/src/util/testing.rs
+++ b/src/util/testing.rs
@@ -12,12 +12,12 @@
 
 /// Alias for [`crate::MotionProfile`] with some extras, used by the tests here
 pub trait MotionProfile:
-    crate::MotionProfile<Velocity = f32> + Default
+    crate::MotionProfile<Velocity = f32, Delay = f32> + Default
 {
 }
 
 impl<T> MotionProfile for T where
-    T: crate::MotionProfile<Velocity = f32> + Default
+    T: crate::MotionProfile<Velocity = f32, Delay = f32> + Default
 {
 }
 
@@ -27,6 +27,7 @@ where
     Profile: MotionProfile,
 {
     position_mode_must_produce_correct_number_of_steps(Profile::default());
+    position_mode_must_respect_maximum_velocity(Profile::default());
 }
 
 /// A motion in position mode must produce the correct number of steps
@@ -37,4 +38,19 @@ pub fn position_mode_must_produce_correct_number_of_steps(
     profile.enter_position_mode(1000.0, num_steps);
 
     assert_eq!(profile.ramp().count() as u32, num_steps);
+}
+
+/// A motion in position mode must respect the maximum velocity
+pub fn position_mode_must_respect_maximum_velocity(
+    mut profile: impl MotionProfile,
+) {
+    let max_velocity = 1000.0;
+    profile.enter_position_mode(max_velocity, 200);
+
+    let min_delay = 0.001;
+
+    for delay in profile.ramp() {
+        println!("delay: {}, min_delay: {}", delay, min_delay);
+        assert!(delay >= min_delay);
+    }
 }

--- a/src/util/testing.rs
+++ b/src/util/testing.rs
@@ -29,6 +29,7 @@ where
     position_mode_must_produce_correct_number_of_steps(Profile::default());
     position_mode_must_respect_maximum_velocity(Profile::default());
     position_mode_must_not_panic_because_of_zero_velocity(Profile::default());
+    position_mode_must_not_panic_because_of_zero_steps(Profile::default());
 }
 
 /// A motion in position mode must produce the correct number of steps
@@ -66,5 +67,13 @@ pub fn position_mode_must_not_panic_because_of_zero_velocity(
     mut profile: impl MotionProfile,
 ) {
     profile.enter_position_mode(0.0, 200);
+    assert_eq!(profile.next_delay(), None);
+}
+
+/// Entering position mode with a target of zero steps must not cause a panic
+pub fn position_mode_must_not_panic_because_of_zero_steps(
+    mut profile: impl MotionProfile,
+) {
+    profile.enter_position_mode(1000.0, 0);
     assert_eq!(profile.next_delay(), None);
 }

--- a/src/util/testing.rs
+++ b/src/util/testing.rs
@@ -39,12 +39,7 @@ pub fn position_mode_must_produce_correct_number_of_steps(
     let num_steps = 200;
     profile.enter_position_mode(1000.0, num_steps);
 
-    let mut count = 0;
-    while let Some(_delay) = profile.next_delay() {
-        count += 1;
-    }
-
-    assert_eq!(count, num_steps);
+    assert_eq!(profile.iter().count() as u32, num_steps);
 }
 
 /// A motion in position mode must respect the maximum velocity
@@ -56,7 +51,7 @@ pub fn position_mode_must_respect_maximum_velocity(
 
     let min_delay = 0.001;
 
-    while let Some(delay) = profile.next_delay() {
+    for delay in profile.iter() {
         println!("delay: {}, min_delay: {}", delay, min_delay);
         assert!(delay >= min_delay);
     }

--- a/src/util/testing.rs
+++ b/src/util/testing.rs
@@ -25,8 +25,10 @@ where
 
 /// A motion in position mode must produce the correct number of steps
 pub fn position_mode_must_produce_correct_number_of_steps(
-    profile: impl MotionProfile,
+    mut profile: impl MotionProfile,
 ) {
     let num_steps = 200;
-    assert_eq!(profile.ramp(num_steps).count() as u32, num_steps);
+    profile.enter_position_mode(num_steps);
+
+    assert_eq!(profile.ramp().count() as u32, num_steps);
 }


### PR DESCRIPTION
Updates and extends the `MotionProfile` trait, making it more powerful and flexible. This is a step towards addressing #5.

This pull request leaves `Trapezoidal` in a bit of a weird state, as it now has a more powerful interface without actually being able to support that. It's no worse than before though, so the previous usage patterns will keep working with the new API. I am going to make `Trapezoidal` more flexible (and address #5 fully) in a follow-up PR.