### PR TITLE
Add additional iterators to `MotionProfile`

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,7 +12,7 @@ fn main() {
     let num_steps = 2000;
     profile.enter_position_mode(max_velocity, num_steps);
 
-    for delay in profile.iter() {
+    for delay in profile.delays() {
         // How you handle a delay depends on the platform you're running on
         // (RampMaker works pretty much everywhere). Here, we use a fake `Timer`
         // API, to demonstrate how the delays produced by RampMaker must be

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -110,9 +110,11 @@ mod tests {
     fn flat_should_produce_constant_velocity() {
         let mut flat = Flat::new();
 
-        flat.enter_position_mode(2.0, 200);
-        for delay in flat.delays() {
-            assert_eq!(delay, 0.5);
+        let max_velocity = 1000.0;
+        flat.enter_position_mode(max_velocity, 200);
+
+        for velocity in flat.velocities() {
+            assert_eq!(velocity, max_velocity);
         }
     }
 }

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -111,7 +111,7 @@ mod tests {
         let mut flat = Flat::new();
 
         flat.enter_position_mode(2.0, 200);
-        for delay in flat.iter() {
+        for delay in flat.delays() {
             assert_eq!(delay, 0.5);
         }
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,5 +1,7 @@
 //! Iterators used in conjunction with [`MotionProfile`]
 
+use num_traits::Inv as _;
+
 use crate::MotionProfile;
 
 /// An iterator over delay values
@@ -15,5 +17,22 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next_delay()
+    }
+}
+
+/// An iterator over velocity values
+///
+/// Can be created by calling [`MotionProfile::velocities`].
+pub struct Velocities<'r, Profile>(pub &'r mut Profile);
+
+impl<'r, Profile> Iterator for Velocities<'r, Profile>
+where
+    Profile: MotionProfile,
+    Profile::Delay: num_traits::Inv<Output = Profile::Velocity>,
+{
+    type Item = Profile::Velocity;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next_delay().map(|delay| delay.inv())
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,19 @@
+//! Iterators used in conjunction with [`MotionProfile`]
+
+use crate::MotionProfile;
+
+/// An iterator over delay values
+///
+/// Can be created by calling [`MotionProfile::delays`].
+pub struct DelayIter<'r, T>(pub &'r mut T);
+
+impl<'r, T> Iterator for DelayIter<'r, T>
+where
+    T: MotionProfile,
+{
+    type Item = T::Delay;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next_delay()
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -5,9 +5,9 @@ use crate::MotionProfile;
 /// An iterator over delay values
 ///
 /// Can be created by calling [`MotionProfile::delays`].
-pub struct DelayIter<'r, T>(pub &'r mut T);
+pub struct Delays<'r, T>(pub &'r mut T);
 
-impl<'r, T> Iterator for DelayIter<'r, T>
+impl<'r, T> Iterator for Delays<'r, T>
 where
     T: MotionProfile,
 {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,6 +1,8 @@
 //! Iterators used in conjunction with [`MotionProfile`]
 
-use num_traits::Inv as _;
+use core::{marker::PhantomData, ops};
+
+use num_traits::{Inv as _, One as _};
 
 use crate::MotionProfile;
 
@@ -34,5 +36,80 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next_delay().map(|delay| delay.inv())
+    }
+}
+
+/// An iterator over acceleration values
+///
+/// Can be created by calling [`MotionProfile::accelerations`].
+pub struct Accelerations<'r, Profile: MotionProfile, Accel> {
+    /// The motion profile
+    pub profile: &'r mut Profile,
+
+    /// The previous delay value
+    pub delay_prev: Option<Profile::Delay>,
+
+    _accel: PhantomData<Accel>,
+}
+
+impl<'r, Profile, Accel> Accelerations<'r, Profile, Accel>
+where
+    Profile: MotionProfile,
+{
+    /// Create a new instance of `Accelerations`
+    ///
+    /// You can call [`MotionProfile::accelerations`] instead.
+    pub fn new(profile: &'r mut Profile) -> Self {
+        let delay_prev = profile.next_delay();
+
+        Self {
+            profile,
+            delay_prev,
+            _accel: PhantomData,
+        }
+    }
+}
+
+impl<'r, Profile, Accel> Iterator for Accelerations<'r, Profile, Accel>
+where
+    Profile: MotionProfile,
+    Profile::Delay: Copy
+        + num_traits::One
+        + num_traits::Inv<Output = Profile::Velocity>
+        + ops::Add<Output = Profile::Delay>
+        + ops::Div<Output = Profile::Delay>,
+    Profile::Velocity: ops::Sub<Output = Profile::Velocity>
+        + ops::Div<Profile::Delay, Output = Accel>,
+{
+    type Item = Accel;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let delay_next = self.profile.next_delay()?;
+
+        let mut accel = None;
+        if let Some(delay_prev) = self.delay_prev {
+            let velocity_prev = delay_prev.inv();
+            let velocity_next = delay_next.inv();
+
+            let velocity_diff = velocity_next - velocity_prev;
+
+            let two = Profile::Delay::one() + Profile::Delay::one();
+
+            // - Assumes the velocity defined by a given delay to be reached at
+            //   the mid-point between the two steps that the delay separates.
+            // - Because of this, the interval between the time of the velocity
+            //   being reached and the time of a neighboring step being
+            //   initiated, is half the delay (the delay measures the interval
+            //   between two steps).
+            // - Therefore, the formula below computes the difference between
+            //   the points in time at which the two velocities are reached.
+            let time_diff = delay_prev / two + delay_next / two;
+
+            accel = Some(velocity_diff / time_diff);
+        }
+
+        self.delay_prev = Some(delay_next);
+
+        accel
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -5,13 +5,13 @@ use crate::MotionProfile;
 /// An iterator over delay values
 ///
 /// Can be created by calling [`MotionProfile::delays`].
-pub struct Delays<'r, T>(pub &'r mut T);
+pub struct Delays<'r, Profile>(pub &'r mut Profile);
 
-impl<'r, T> Iterator for Delays<'r, T>
+impl<'r, Profile> Iterator for Delays<'r, Profile>
 where
-    T: MotionProfile,
+    Profile: MotionProfile,
 {
-    type Item = T::Delay;
+    type Item = Profile::Delay;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next_delay()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub trait MotionProfile: Sized {
     /// method.
     fn next_delay(&mut self) -> Option<Self::Delay>;
 
-    /// Return an iterator over delay values
+    /// Return an iterator over delay values of each step
     ///
     /// This is a convenience method that returns an iterator which internally
     /// just calls [`MotionProfile::next_delay`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 #![deny(missing_docs, broken_intra_doc_links)]
 
 pub mod flat;
+pub mod iter;
 pub mod trapezoidal;
 pub mod util;
 
@@ -83,23 +84,7 @@ pub trait MotionProfile: Sized {
     ///
     /// This is a convenience method that returns an iterator which internally
     /// just calls [`MotionProfile::next_delay`].
-    fn delays(&mut self) -> DelayIter<Self> {
-        DelayIter(self)
-    }
-}
-
-/// An iterator over delay values
-///
-/// Can be created by calling [`MotionProfile::delays`].
-pub struct DelayIter<'r, T>(pub &'r mut T);
-
-impl<'r, T> Iterator for DelayIter<'r, T>
-where
-    T: MotionProfile,
-{
-    type Item = T::Delay;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next_delay()
+    fn delays(&mut self) -> iter::DelayIter<Self> {
+        iter::DelayIter(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub trait MotionProfile: Sized {
     ///
     /// This is a convenience method that returns an iterator which internally
     /// just calls [`MotionProfile::next_delay`].
-    fn delays(&mut self) -> iter::DelayIter<Self> {
-        iter::DelayIter(self)
+    fn delays(&mut self) -> iter::Delays<Self> {
+        iter::Delays(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,4 +98,15 @@ pub trait MotionProfile: Sized {
     fn velocities(&mut self) -> iter::Velocities<Self> {
         iter::Velocities(self)
     }
+
+    /// Return an iterator over the acceleration values between steps
+    ///
+    /// This is a convenience method that returns an iterator which internally
+    /// calls [`MotionProfile::next_delay`] and computes the acceleration from
+    /// each pair of delay values.
+    ///
+    /// This is mainly useful for testing and debugging.
+    fn accelerations<Accel>(&mut self) -> iter::Accelerations<Self, Accel> {
+        iter::Accelerations::new(self)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,4 +87,15 @@ pub trait MotionProfile: Sized {
     fn delays(&mut self) -> iter::Delays<Self> {
         iter::Delays(self)
     }
+
+    /// Return an iterator over velocity values of each step
+    ///
+    /// This is a convenience method that returns an iterator which internally
+    /// calls [`MotionProfile::next_delay`] and converts the delay to a
+    /// velocity.
+    ///
+    /// This is mainly useful for testing and debugging.
+    fn velocities(&mut self) -> iter::Velocities<Self> {
+        iter::Velocities(self)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,21 +75,22 @@ pub trait MotionProfile: Sized {
     /// All other details of the motion profile are implementation-defined.
     ///
     /// If you need an iterator that produces the step delays, you can get one
-    /// by calling [`MotionProfile::iter`], which internally calls this method.
+    /// by calling [`MotionProfile::delays`], which internally calls this
+    /// method.
     fn next_delay(&mut self) -> Option<Self::Delay>;
 
     /// Return an iterator over delay values
     ///
     /// This is a convenience method that returns an iterator which internally
     /// just calls [`MotionProfile::next_delay`].
-    fn iter(&mut self) -> DelayIter<Self> {
+    fn delays(&mut self) -> DelayIter<Self> {
         DelayIter(self)
     }
 }
 
 /// An iterator over delay values
 ///
-/// Can be created by calling [`MotionProfile::iter`].
+/// Can be created by calling [`MotionProfile::delays`].
 pub struct DelayIter<'r, T>(pub &'r mut T);
 
 impl<'r, T> Iterator for DelayIter<'r, T>

--- a/src/trapezoidal.rs
+++ b/src/trapezoidal.rs
@@ -215,7 +215,7 @@ mod tests {
         let mut last_velocity = None;
 
         trapezoidal.enter_position_mode(1000.0, 200);
-        for delay in trapezoidal.iter() {
+        for delay in trapezoidal.delays() {
             let velocity = 1.0 / delay;
             println!("Velocity: {}", velocity);
             last_velocity = Some(velocity);
@@ -244,7 +244,7 @@ mod tests {
         let mut ramped_down = false;
 
         trapezoidal.enter_position_mode(1000.0, 200);
-        for (i, delay_curr) in trapezoidal.iter().enumerate() {
+        for (i, delay_curr) in trapezoidal.delays().enumerate() {
             if let Some(accel) =
                 acceleration_from_delays(&mut delay_prev, delay_curr)
             {
@@ -295,7 +295,7 @@ mod tests {
 
         let mut delay_prev = None;
 
-        for (i, delay_curr) in trapezoidal.iter().enumerate() {
+        for (i, delay_curr) in trapezoidal.delays().enumerate() {
             if let Some(accel) =
                 acceleration_from_delays(&mut delay_prev, delay_curr)
             {

--- a/src/util/testing.rs
+++ b/src/util/testing.rs
@@ -39,7 +39,7 @@ pub fn position_mode_must_produce_correct_number_of_steps(
     let num_steps = 200;
     profile.enter_position_mode(1000.0, num_steps);
 
-    assert_eq!(profile.iter().count() as u32, num_steps);
+    assert_eq!(profile.delays().count() as u32, num_steps);
 }
 
 /// A motion in position mode must respect the maximum velocity
@@ -51,7 +51,7 @@ pub fn position_mode_must_respect_maximum_velocity(
 
     let min_delay = 0.001;
 
-    for delay in profile.iter() {
+    for delay in profile.delays() {
         println!("delay: {}, min_delay: {}", delay, min_delay);
         assert!(delay >= min_delay);
     }

--- a/src/util/testing.rs
+++ b/src/util/testing.rs
@@ -49,11 +49,9 @@ pub fn position_mode_must_respect_maximum_velocity(
     let max_velocity = 1000.0;
     profile.enter_position_mode(max_velocity, 200);
 
-    let min_delay = 0.001;
-
-    for delay in profile.delays() {
-        println!("delay: {}, min_delay: {}", delay, min_delay);
-        assert!(delay >= min_delay);
+    for velocity in profile.velocities() {
+        println!("velocity: {}, max velocity: {}", velocity, max_velocity);
+        assert!(velocity <= max_velocity);
     }
 }
 


### PR DESCRIPTION
In addition to the iterator over delay values, add new iterators over velocity and acceleration values. This is mostly useful for debugging and testing, and makes some utility code used by the tests publicly available.